### PR TITLE
Port to MacOs / Add drop support in the main menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,20 @@
     "devDependencies": {
         "custom-electron-titlebar": "^3.0.9",
         "electron": "^5.0.4",
-        "electron-builder": "^21.1.1"
+        "electron-builder": "^21.2.0"
     },
     "build": {
         "appId": "lector",
         "productName": "Lector",
         "copyright": "Copyright (c) 2019 Sagar Gurtu",
         "buildVersion": "1.1.0",
+        "mac": {
+            "icon": "./src/assets/icons/mac/icon.icns",
+            "fileAssociations": {
+                "ext": "pdf",
+                "icon": "./src/assets/icons/mac/icon.icns"
+            }
+        },
         "win": {
             "target": "NSIS",
             "icon": "./src/assets/icons/win/icon.ico",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -475,6 +475,9 @@
             this._setWindowEvents();
             this._setExternalEvents();
             this._processRemoteArguments();
+
+            // On MacOs, notify the main process that this has finished loading
+            if (process.platform === 'darwin') ipcRenderer.send("web-loaded");
         }
 
     }

--- a/src/js/menutemplate.js
+++ b/src/js/menutemplate.js
@@ -63,6 +63,7 @@ exports.buildMenuTemplate = function (win) {
                 },
                 {
                     label: 'Exit',
+                    accelerator: ((process.platform === 'darwin')? 'CmdOrCtrl+Q' : ''), // listen on MacOs for Command+Q to exit
                     click() {
                         app.quit()
                     }


### PR DESCRIPTION
* Bump the version of 'electron-builder' to 21.2.0, since [this is the minimum required version for MacOs (Catalina)](https://github.com/electron-userland/electron-builder/issues/3990#issuecomment-553734294)
* Instead of command-line arguments, use ```app.on('open-file', (event, path) => {...}``` to get files to be opened at program start. General idea described [here](https://medium.com/@roysegall/electron-open-with-for-mac-osx-f215a1fe2ce1).
* Set ``titleBarStyle: 'hidden'``, to hide the original title bar, but to keep the 'close', 'minimize' and 'maximize' options in the custom title bar
* Use ipc to tell the main process, when the web page has finished loading to keep the the 'Open With' option working when the program is already running
* Add 'mac' build option